### PR TITLE
Fix the server routing issue

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Single Page Apps for GitHub Pages</title>
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafrex/spa-github-pages
+    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+    // ----------------------------------------------------------------------
+    // This script takes the current url and converts the path and query
+    // string into just a query string, and then redirects the browser
+    // to the new url with only a query string and hash fragment,
+    // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+    // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+    // Note: this 404.html file must be at least 512 bytes for it to work
+    // with Internet Explorer (it is currently > 512 bytes)
+
+    // If you're creating a Project Pages site and NOT using a custom domain,
+    // then set segmentCount to 1 (enterprise users may need to set it to > 1).
+    // This way the code will only replace the route part of the path, and not
+    // the real directory in which the app resides, for example:
+    // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+    // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
+    // Otherwise, leave segmentCount as 0.
+    var segmentCount = 0;
+
+    var l = window.location;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+      l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+      (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+      l.hash
+    );
+
+  </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,39 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafrex/spa-github-pages
+    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+    // ----------------------------------------------------------------------
+    // This script checks to see if a redirect is present in the query string
+    // and converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function (l) {
+      if (l.search) {
+        var q = {};
+        l.search.slice(1).split('&').forEach(function (v) {
+          var a = v.split('=');
+          q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
+        });
+        if (q.p !== undefined) {
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + (q.p || '') +
+            (q.q ? ('?' + q.q) : '') +
+            l.hash
+          );
+        }
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
+
   <link rel="shortcut icon" href="./src/favicon.ico">
   <title>Index</title>
 </head>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "Apache License Version 2.0",
 	"scripts": {
 		"start": "node server.js",
-		"build": "parcel build index.html && cp CNAME dist/CNAME"
+		"build": "parcel build index.html && cp CNAME 404.html dist/"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.3",


### PR DESCRIPTION
Since github doesn’t natively support single page apps, this change is
for fixing the server routing issue. (The problem does not happen in
local env)

There is an second part of the change, 404.html. It is delivered to
gh-pages branch
https://github.com/AdoptOpenJDK/openjdk-dashboard-v2/blob/gh-pages/404.html
Please do NOT remove this 404.html when deploying new changes in
gh-pages branch.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>