### PR TITLE
Update CNAME to new host

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-dash-v2.adoptopenjdk.net
+dash.adoptopenjdk.net


### PR DESCRIPTION
The v2 repo is now being used to serve up dash.adoptopenjdk.net.