### PR TITLE
Revert "Bump path-parse from 1.0.6 to 1.0.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5563,9 +5563,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
 		"path-to-regexp": {


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-dashboard-v2#29